### PR TITLE
fixed info offset bug for quests edited by MH4U quest editor by dasding

### DIFF
--- a/mh4u_proxy.py
+++ b/mh4u_proxy.py
@@ -20,7 +20,8 @@ def make_quests(path, cipher, language, quest_files):
     quests_page = ''
     for i in range(len(quest_files)):
         quest = open(quest_files[i], 'rb')
-        quest.seek(0xa0)
+        info_offset = struct.unpack('I',quest.read(4))
+        quest.seek(info_offset[0])
         info = struct.unpack('8I2H3B33x5H', quest.read(82))
         quest.seek(info[7])
         language_offset = struct.unpack('5I', quest.read(20))


### PR DESCRIPTION
I saw you use 
   quest.seek(0xa0)
to locate the info structure. 0xa0 may works well for all original quests but fails on some quests edited by MH4U quest editor by dasding. You can find it [here](https://www.reddit.com/r/MonsterHunterCustoms/comments/3fnva8/monster_hunter_4_ultimate_custom_quest_editor_by/).
In deed the offset of the info structure is the first integer in the decrypted mib file, so I made these changes. Please see the attached xxd dump of the quest edited by the editor I mentioned. You can see the info structure is located at 0x09c0, and 0x09c0 appears in the head of the file. 

[m60217.txt](https://github.com/svanheulen/mhqs/files/310167/m60217.txt)
